### PR TITLE
Center the video on larger screens

### DIFF
--- a/src/assets/scss/_style.scss
+++ b/src/assets/scss/_style.scss
@@ -16,10 +16,17 @@ body {
   background: #000;
 }
 
-.video-container video {
+.video-wrap {
   position: absolute;
-  z-index: 0;
+  left: 50%;
   bottom: 0;
+  z-index: 0;
+}
+
+.video-container video {
+  position: relative;
+  left: -50%;
+  vertical-align: bottom;
   width: auto;
   height: auto;
 }

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1,8 +1,10 @@
 <div class="hero">
   <div class="video-container">
-    <video preload="auto" autoplay="autoplay" loop="loop" class="fillWidth">
-      <source src="assets/video/Northernlights2_HD.mp4" type="video/mp4"/>
-    </video>
+    <div class="video-wrap">
+      <video preload="auto" autoplay="autoplay" loop="loop" class="fillWidth">
+        <source src="assets/video/Northernlights2_HD.mp4" type="video/mp4"/>
+      </video>
+    </div>
 
     <div class="video-overlay"></div>
 


### PR DESCRIPTION
Problem:
On larger screens video floats left.
![geekatrons collective - nightly_005](https://user-images.githubusercontent.com/204514/35408605-17a55024-0210-11e8-8363-f301e6152b48.jpg)

Result:
The video is centered.
![geekatrons collective - nightly_004](https://user-images.githubusercontent.com/204514/35408641-31def878-0210-11e8-8193-796734fdc6fc.jpg)

Please review the code. If there is a more elegant solution, I am super eager to learn.